### PR TITLE
Don't require space for ruby_hash_style

### DIFF
--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -19,6 +19,7 @@ let g:switch_builtins =
       \   },
       \   'ruby_hash_style': {
       \     ':\(\k\+\)\s\+=>': '\1:',
+      \     ':\(\k\+\)=>': '\1: ',
       \     '\<\(\k\+\): ':    ':\1 => ',
       \   },
       \   'ruby_if_clause': {


### PR DESCRIPTION
Add rule, ':(\k+)=>': '\1: '
