### PR TITLE
add clojure support (string and if-clause)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,32 @@ functionCall (foo) ->
 functionCall (foo) =>
 ```
 
+### Clojure
+
+* String style:
+  ``` clojure
+  "baz"
+  'bar
+  :baz
+  ```
+  (Note that it only works for single-word strings, such as `baz`, `b-a-z`, or `**`.)
+
+* If-clauses:
+  ``` clojure
+  (if predicate?
+    (prn "Hello, world!")
+    (prn "oh..."))
+
+  (if (or true predicate?)
+    (prn "Hello, world!")
+    (prn "oh..."))
+
+  (if (and false predicate?)
+    (prn "Hello, world!")
+    (prn "oh..."))
+  ```
+  (Note that it also works for `if-not`, `when`, and `when-not`.)
+
 ## Similar work
 
 This plugin is very similar to two other ones:

--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -378,6 +378,32 @@ Arrows (g:switch_builtins.coffee_arrow):
     functionCall (foo) =>
 <
 
+Clojure ~
+
+String style (g:switch_builtins.clojure_string):
+>
+    "baz"
+    'bar
+    :baz
+<
+Note that it only works for single-word strings, such as baz, b-a-z, or **.
+
+If-clauses (g:switch_builtins.clojure_if_clause):
+>
+    (if predicate?
+      (prn "Hello, world!")
+      (prn "oh..."))
+
+    (if (or true predicate?)
+      (prn "Hello, world!")
+      (prn "oh..."))
+
+    (if (and false predicate?)
+      (prn "Hello, world!")
+      (prn "oh..."))
+<
+Note that it also works for if-not, when, and when-not.
+
 ==============================================================================
 SETTINGS                                                *switch-similar-plugins*
 

--- a/examples/example.clj
+++ b/examples/example.clj
@@ -1,0 +1,4 @@
+(when something
+  (let [flag true
+        baz "foo"]
+    ...))

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -76,6 +76,16 @@ let g:switch_builtins =
       \     '^\(.*\)->': '\1=>',
       \     '^\(.*\)=>': '\1->',
       \   },
+      \   'clojure_string': {
+      \     '"\(\k\+\)"': '''\1',
+      \     '''\(\k\+\)': ':\1',
+      \     ':\(\k\+\)':  '"\1"\2',
+      \   },
+      \   'clojure_if_clause': {
+      \     '(\(if\|if-not\|when\|when-not\) (or true \(.*\))':   '(\1 (and false \2)',
+      \     '(\(if\|if-not\|when\|when-not\) (and false \(.*\))': '(\1 \2',
+      \     '(\(if\|if-not\|when\|when-not\) (\@!\(.*\)':         '(\1 (or true \2)',
+      \   },
       \ }
 
 let g:switch_definitions =
@@ -118,6 +128,12 @@ autocmd FileType cpp let b:switch_definitions =
 autocmd FileType coffee let b:switch_definitions =
       \ [
       \   g:switch_builtins.coffee_arrow,
+      \ ]
+
+autocmd FileType clojure let b:switch_definitions =
+      \ [
+      \   g:switch_builtins.clojure_string,
+      \   g:switch_builtins.clojure_if_clause,
       \ ]
 
 command! Switch call s:Switch()

--- a/spec/plugin/clojure_spec.rb
+++ b/spec/plugin/clojure_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe "clojure definitions" do
+  let(:filename) { 'test.clj' }
+
+  specify "true/false" do
+    set_file_contents '(def flag true)'
+    vim.set 'filetype', 'clojure'
+
+    vim.search('true').switch
+    assert_file_contents '(def flag false)'
+
+    vim.switch
+    set_file_contents '(def flag true)'
+
+    vim.search('flag').switch
+    set_file_contents '(def flag true)'
+  end
+
+  specify "if-clauses" do
+    set_file_contents <<-EOF
+      (if predicate?
+        (prn "Hello, world!")
+        (prn "oh..."))
+    EOF
+    vim.set 'filetype', 'clojure'
+
+    vim.search 'if'
+
+    vim.switch
+    assert_file_contents <<-EOF
+      (if (or true predicate?)
+        (prn "Hello, world!")
+        (prn "oh..."))
+    EOF
+
+    vim.switch
+    assert_file_contents <<-EOF
+      (if (and false predicate?)
+        (prn "Hello, world!")
+        (prn "oh..."))
+    EOF
+
+    vim.switch
+    assert_file_contents <<-EOF
+      (if predicate?
+        (prn "Hello, world!")
+        (prn "oh..."))
+    EOF
+  end
+
+  specify "string type" do
+    set_file_contents '(def foo "bar")'
+    vim.set 'filetype', 'clojure'
+
+    vim.search('bar').switch
+    assert_file_contents "(def foo 'bar)"
+
+    vim.switch
+    assert_file_contents "(def foo :bar)"
+
+    vim.switch
+    assert_file_contents '(def foo "bar")'
+  end
+
+  pending "see #10; &iskeyword depends on your Vim's clojure support" do
+    specify "string type" do
+      set_file_contents '(def foo "ba-r!")'
+      vim.set 'filetype', 'clojure'
+
+      vim.search('ba-r').switch
+      assert_file_contents "(def foo 'ba-r!)"
+
+      vim.switch
+      assert_file_contents "(def foo :ba-r!)"
+
+      vim.switch
+      assert_file_contents '(def foo "ba-r!")'
+    end
+  end
+end


### PR DESCRIPTION
Added following features for `filetype=clojure`
- string - symbol - keyword switch (like ruby's string - symbol switch)
- if clause switch (like ruby's)

``` clojure
"hello-world"
'hello-world
:hello-world
```

``` clojure
(if boolean-value
  something
  otherwise)

(if (or true boolean-value)
  something
  otherwise)

(if (and false boolean-value)
  something
  otherwise)
```

vimrunner test passed on my environment. It may depend on your `ftdetect` and `ftplugin`, since this spec depends on your `&iskeyword` value which is usually set by `&lisp`.

I didn't add sentences in README and doc/switch.txt about these new features yet. If you think this pull request satisfies your requirements, I'm happy to write docs.
