### PR TITLE
add scala support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,18 @@ functionCall (foo) =>
   ```
   (Note that it also works for `if-not`, `when`, and `when-not`.)
 
+### Scala
+
+* String style:
+  ``` scala
+  "foo bar"
+  s"foo bar"
+  f"foo bar"
+  """foo bar"""
+  s"""foo bar"""
+  f"""foo bar"""
+  ```
+
 ## Similar work
 
 This plugin is very similar to two other ones:

--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -406,6 +406,18 @@ If-clauses (g:switch_builtins.clojure_if_clause):
 <
 Note that it also works for if-not, when, and when-not.
 
+Scala ~
+
+String style (g:switch_builtins.scala_string):
+>
+    "foo bar"
+    s"foo bar"
+    f"foo bar"
+    """foo bar"""
+    s"""foo bar"""
+    f"""foo bar"""
+<
+
 ==============================================================================
 SETTINGS                                                       *switch-settings*
 

--- a/examples/example.scala
+++ b/examples/example.scala
@@ -1,0 +1,1 @@
+val baz = "foo"

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -86,6 +86,14 @@ let g:switch_builtins =
       \     '(\(if\|if-not\|when\|when-not\) (and false \(.*\))': '(\1 \2',
       \     '(\(if\|if-not\|when\|when-not\) (\@!\(.*\)':         '(\1 (or true \2)',
       \   },
+      \   'scala_string': {
+      \     '[sf"]\@<!"\(\%(\\.\|.\)\{-}\)""\@!': 's"\1"',
+      \     's"\(\%(\\.\|.\)\{-}\)"':             'f"\1"',
+      \     'f"\(\%(\\.\|.\)\{-}\)"':             '"""\1"""',
+      \     '[sf"]\@<!"""\(.\{-}\)"""':           's"""\1"""',
+      \     's"""\(.\{-}\)"""':                   'f"""\1"""',
+      \     'f"""\(.\{-}\)"""':                   '"\1"',
+      \   },
       \ }
 
 let g:switch_definitions =
@@ -134,6 +142,10 @@ autocmd FileType clojure let b:switch_definitions =
       \ [
       \   g:switch_builtins.clojure_string,
       \   g:switch_builtins.clojure_if_clause,
+      \ ]
+autocmd FileType scala let b:switch_definitions =
+      \ [
+      \   g:switch_builtins.scala_string,
       \ ]
 
 command! Switch call s:Switch()

--- a/spec/plugin/scala_spec.rb
+++ b/spec/plugin/scala_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe "scala definitions" do
+  let(:filename) { 'test.scala' }
+
+  specify "true/false" do
+    set_file_contents 'val flag = true'
+    vim.set 'filetype', 'scala'
+
+    vim.search('true').switch
+    assert_file_contents 'val flag = false'
+
+    vim.switch
+    set_file_contents 'val flag = true'
+
+    vim.search('flag').switch
+    set_file_contents 'val flag = true'
+  end
+
+  specify "string type" do
+    set_file_contents 'val foo = "bar"'
+    vim.set 'filetype', 'scala'
+
+    vim.search('bar').switch
+    assert_file_contents 'val foo = s"bar"'
+
+    vim.switch
+    assert_file_contents 'val foo = f"bar"'
+
+    vim.switch
+    assert_file_contents 'val foo = """bar"""'
+
+    vim.switch
+    assert_file_contents 'val foo = s"""bar"""'
+
+    vim.switch
+    assert_file_contents 'val foo = f"""bar"""'
+
+    vim.switch
+    assert_file_contents 'val foo = "bar"'
+  end
+end


### PR DESCRIPTION
Added string conversion for `filetype=scala`

``` scala
"foo bar"
s"foo bar"
f"foo bar"
"""foo bar"""
s"""foo bar"""
f"""foo bar"""
```

Scala has multiple string literals, and it's pretty common to switch them.
