### PR TITLE
Add `doc/tags` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Calling pathogen#helptags() generates a `doc/tags` file in the switch.vim bundle. I added it to gitignore, because it's an annoyance when using switch.vim as a submodule.
