### PR TITLE
avoid overwriting variable passed as configuration

### DIFF
--- a/autoload/switch.vim
+++ b/autoload/switch.vim
@@ -4,7 +4,7 @@ function! switch#Switch(definitions)
   try
     let saved_cursor = getpos('.')
     let min_match    = switch#match#Null()
-    let definitions  = switch#util#FlatMap(a:definitions, 'switch#mapping#Process(v:val)')
+    let definitions  = switch#util#FlatMap(copy(a:definitions), 'switch#mapping#Process(v:val)')
 
     for mapping in definitions
       let match = mapping.Match()


### PR DESCRIPTION
Hi, 

i tried to use setting to translate snake case into camel case in README, but it did not work when executed twice or more. 
i found the global variable that have the matching rules was modified to other form in util#FlatMap. i comfirmed that it worked properly after modified.