### PR TITLE
Fix documentation reference to builtins.capitalized_true_false

### DIFF
--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -307,7 +307,7 @@ Boolean constants (g:switch_builtins.true_false):
     flag = true
     flag = false
 <
-Capitalized boolean constants (g:switch_builtins.capitalized_true_false):
+Capitalized boolean constants (g:switch_builtins.capital_true_false):
 >
     flag = True
     flag = False


### PR DESCRIPTION
The actual key is `capital_true_false`: https://github.com/AndrewRadev/switch.vim/blob/master/plugin/switch.vim#L24
This changes the documentation to match that.