### PR TITLE
Call <C-A>/<C-X> when unable to Switch

### DIFF
--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -7,11 +7,11 @@ let s:keepcpo = &cpo
 set cpo&vim
 
 if !exists('g:switch_mapping')
-  let g:switch_mapping = 'gs'
+  let g:switch_mapping = '<C-A>'
 endif
 
 if !exists('g:switch_reverse_mapping')
-  let g:switch_reverse_mapping = ''
+  let g:switch_reverse_mapping = '<C-X>'
 endif
 
 if !exists('g:switch_find_smallest_match')
@@ -212,14 +212,18 @@ autocmd FileType scala let b:switch_definitions =
 command! Switch call s:Switch()
 function! s:Switch()
   let definitions = s:GetDefinitions()
-  call switch#Switch(definitions, {})
+  if !switch#Switch(definitions, {})
+    exe "normal! \<C-A>"
+  endif
   silent! call repeat#set(":Switch\<cr>")
 endfunction
 
 command! SwitchReverse call s:SwitchReverse()
 function! s:SwitchReverse()
   let definitions = s:GetDefinitions()
-  call switch#Switch(definitions, {'reverse': 1})
+  if !switch#Switch(definitions, {'reverse': 1})
+    exe "normal! \<C-X>"
+  endif
   silent! call repeat#set(":Switch\<cr>")
 endfunction
 


### PR DESCRIPTION
When `:Switch` cannot replace under the cursor, call `<C-A>`/`<C-X>` instead.

The current implementation has several (unwanted?) side-effects:
- Changes the default binding from `gs` to `<C-A>`
- `<C-A>`/`<C-X>` is always called when `:Switch` doesn't match, even if `g:switch_mapping` is set to something other than `<C-A>`
- with `_cursor  false   42`, `:Switch` would jump over `false` and change the number, which might be a bit surprising

What do you think? I could add an option to enable/disable calling `^a` for any `g:switch_mapping` or try to pass the original mapping if `:Switch` failed, i.e. if `g:switch_mapping == "gs"`, call the original `gs` mapping.
