### PR TITLE
Add ES6 (var/let/const) switch mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,17 @@ Object* foo = bar->baz;
   var example = (one, two) => { }
   ```
 
+* ES6-style variable declarations:
+  ``` javascript
+  var example
+  let example
+  const example
+  // var -> let
+  // let -> const
+  // const -> let
+  ```
+  Switching to var from const or let is unsupported, since it's assumed to be an unlikely case.
+
 ### Coffeescript arrows
 
 ``` coffeescript

--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -515,6 +515,16 @@ ES6-style arrow functions (g:switch_builtins.javascript_arrow_function)
     var example = function(one, two) { }
     var example = (one, two) => { }
 <
+ES6-style variable declaraions (g:switch_builtins.javascript_es6_declarations)
+>
+    var example
+    let example
+    const example
+    // var -> let
+    // let -> const
+    // const -> let
+<
+Switching to var from const or let is unsupported, since it's assumed to be an unlikely case.
 
 Coffeescript ~
 

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -116,6 +116,11 @@ let g:switch_builtins =
       \     '(\([^()]\{-}\))\s*=>\s*{':                 'function(\1) {',
       \     '\(\k\+\)\s*=>\s*{':                        'function(\1) {',
       \   },
+      \   'javascript_es6_declarations': {
+      \     '\<var\s\+': 'let ',
+      \     '\<let\s\+': 'const ',
+      \     '\<const\s\+': 'let ',
+      \   },
       \   'coffee_arrow': {
       \     '^\(.*\)->': '\1=>',
       \     '^\(.*\)=>': '\1->',
@@ -199,6 +204,7 @@ autocmd FileType javascript let b:switch_definitions =
       \ [
       \   g:switch_builtins.javascript_function,
       \   g:switch_builtins.javascript_arrow_function,
+      \   g:switch_builtins.javascript_es6_declarations,
       \ ]
 
 autocmd FileType coffee let b:switch_definitions =


### PR DESCRIPTION
Me again 😄

This PR adds a switch mapping for all the ES6 variable declaration styles. It takes a `var ` keyword and changes it to `let `, `let ` to `const `, and `const ` goes to `let `. This could be contentious - you might have noticed that it means you cannot go back to `var ` - the way I see it, `var` is - in an ES6 world - a legacy option, and would seldom be needed, but `const` and `let` are something that gets switched around frequently.

Let me know your thoughts, hopefully I've done it all correctly this time 😄 