### PR TITLE
Add switch definitions for Elixir lists and strings

### DIFF
--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -589,6 +589,29 @@ Git Rebase Commands:
     s -> exec
     x -> drop
     d -> pick
+
+Elixir ~
+
+Charlist -> Binary -> Atom (g:switch_builtins.ruby_string)
+>
+    foo = 'bar'
+    foo = "bar"
+    foo = :bar
+<
+Elixir list shorthands (g:switch_builtins.elixir_list_shorthand)
+>
+    ["one", "two", "three"]
+    ~w(one two three)
+
+    [:one, :two, :three]
+    ~w(one two three)a
+<
+Capitalized boolean constants (g:switch_builtins.capital_true_false):
+>
+    flag = True
+    flag = False
+<
+
 <
 
 ==============================================================================

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -147,6 +147,28 @@ let g:switch_builtins =
       \     's"""\(.\{-}\)"""':                   'f"""\1"""',
       \     'f"""\(.\{-}\)"""':                   '"\1"',
       \   },
+      \   'elixir_list_shorthand': {
+      \     '\[\%(\k\|[''", ]\)\+\]': {
+      \       '\[':                    '\~w(',
+      \       '[''"]\(\k\+\)[''"],\=': '\1',
+      \       ']':                     ')',
+      \     },
+      \     '\~w(\%(\k\|\s\)\+)a': {
+      \       '\~w(':      '[',
+      \       '\(\k\+\) ': ':\1, ',
+      \       '\(\k\+\))a': ':\1]',
+      \     },
+      \     '\~w(\%(\k\|\s\)\+)a\@!': {
+      \       '\~w(':      '[',
+      \       '\(\k\+\) ': '"\1", ',
+      \       '\(\k\+\))': '"\1"]',
+      \     },
+      \     '\[\%(\k\|[:, ]\)\+\]': {
+      \       '\[':           '\~w(',
+      \       ':\(\k\+\),\=': '\1',
+      \       ']':            ')a',
+      \     },
+      \   },
       \ }
 
 let g:switch_definitions =
@@ -232,6 +254,11 @@ autocmd FileType gitrebase let b:switch_definitions =
       \   { '^s ': 'exec ' },
       \   { '^x ': 'drop ' },
       \   { '^d ': 'pick ' },
+      \ ]
+autocmd FileType elixir let b:switch_definitions =
+      \ [
+      \   g:switch_builtins.ruby_string,
+      \   g:switch_builtins.elixir_list_shorthand
       \ ]
 
 

--- a/spec/plugin/elixir_spec.rb
+++ b/spec/plugin/elixir_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe "elixir definitions" do
+  let(:filename) { 'test.ex' }
+
+  specify "string type" do
+    set_file_contents 'foo = "bar?"'
+    vim.set 'filetype', 'elixir'
+
+    vim.search('bar').switch
+    assert_file_contents "foo = 'bar?'"
+
+    vim.switch
+    assert_file_contents "foo = :bar?"
+
+    vim.switch
+    assert_file_contents 'foo = "bar?"'
+  end
+
+  specify "list shorthands" do
+    set_file_contents '["one", "two"]'
+    vim.set 'filetype', 'elixir'
+
+    vim.search('[').switch
+    assert_file_contents "~w(one two)"
+
+    vim.switch
+    assert_file_contents '["one", "two"]'
+
+    set_file_contents "[:one, :two]"
+
+    vim.search('[').switch
+    assert_file_contents "~w(one two)a"
+
+    vim.switch
+    assert_file_contents "[:one, :two]"
+  end
+end


### PR DESCRIPTION
The string type switching is literally Ruby's string type switching,
since Elixir syntax works the same way. The lists are a slightly
modified version of Ruby's array literal switching - elixir uses `~w(foo
bar)` for string lists and `~w(foo bar)a` for atom lists