### PR TITLE
Better Ruby fetch builtin switch

### DIFF
--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -84,8 +84,8 @@ let g:switch_builtins =
       \     },
       \   },
       \   'ruby_fetch': {
-      \     '\(\k\+\)\[\(.\{-}\)\]': '\1.fetch(\2)',
-      \     '\(\k\+\)\.fetch(\(.\{-}\))': '\1[\2]',
+      \     '\v(%(\%@<!\k)+)\[(.{-})\]': '\1.fetch(\2)',
+      \     '\v(\k+)\.fetch\((.{-})\)': '\1[\2]',
       \   },
       \   'ruby_assert_nil': {
       \     'assert_equal nil,': 'assert_nil',

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -213,6 +213,11 @@ describe "ruby definitions" do
 
     vim.switch
     assert_file_contents "foo['one']"
+
+    set_file_contents "%w[one]"
+
+    vim.search('w').switch
+    assert_file_contents "%w[one]"
   end
 
   specify "assert_nil" do


### PR DESCRIPTION
Don't apply fetch switch on shorthand arrays.