### PR TITLE
Make vim-speeddating work with switch.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ For example, if you want to switch, or fall back to activating the
 `<c-a>` and `<c-x>` like so:
 
 ``` vim
+let g:speeddating_no_mappings=1
+nnoremap <Plug>SpeedDatingFallbackUp <C-A>
+nnoremap <Plug>SpeedDatingFallbackDown <C-X>
 nnoremap <c-a> :if !switch#Switch() <bar>
       \ call speeddating#increment(v:count1) <bar> endif<cr>
 nnoremap <c-x> :if !switch#Switch({'reverse': 1}) <bar>


### PR DESCRIPTION
Without disable speeddating key mappings and set the speeddating fallback key mappings, these two plugins won't work correctly. 

![image](https://user-images.githubusercontent.com/14842664/85918953-06bf0b00-b81c-11ea-82c9-50952e29c10e.png)

After these changes, switch.vim could work with vim-speeddating smoothly.
