### PR TITLE
:SwitchExtend

### DIFF
--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -116,7 +116,21 @@ There are three main principles that the substition follows:
 If you don't like the "smallest match" algorithm described on top, and you'd
 rather just attempt all matches in order, set the value of
 |g:switch_find_smallest_match| to 0.
+                                                               *:SwitchExtend*
 
+This command provides an easy way to extend your current buffer's custom
+definitions (|b:switch_custom_definitions|). If this variable doesn't exist
+yet, it will be created as a copy of the global custom definitions
+(|g:switch_custom_definitions|), and then extended.
+
+Called without arguments, it prints the current value of this buffer variable,
+that is your custom definitions for the current buffer.
+
+If called with a list or a dictionary as argument, it will extend the custom
+definitions for the current buffer:
+>
+    SwitchExtend ['on', 'off']
+<
 
 ==============================================================================
 ADVANCED USAGE                                           *switch-advanced-usage*

--- a/doc/switch.txt
+++ b/doc/switch.txt
@@ -127,9 +127,9 @@ Called without arguments, it prints the current value of this buffer variable,
 that is your custom definitions for the current buffer.
 
 If called with a list or a dictionary as argument, it will extend the custom
-definitions for the current buffer:
+definitions for the current buffer. Multiple definitions are accepted:
 >
-    SwitchExtend ['on', 'off']
+    SwitchExtend ['on', 'off'], {'\Cif': 'elseif', '\Celseif': 'if'}
 <
 
 ==============================================================================

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -227,6 +227,20 @@ function! s:SwitchReverse()
   silent! call repeat#set(":Switch\<cr>")
 endfunction
 
+command! -nargs=? SwitchExtend call s:SwitchExtend(<args>)
+fun! s:SwitchExtend(...) abort
+  let b:switch_custom_definitions = get(b:, 'switch_custom_definitions',
+      \                                 copy(get(g:, 'switch_custom_definitions', [])))
+  if a:0 == 0
+    echo b:switch_custom_definitions
+  elseif type(a:1) != type({}) && type(a:1) != type([])
+    echo '[switch.vim] argument must be a list or a dictionary'
+  elseif index(b:switch_custom_definitions, a:1) < 0
+    call extend(b:switch_custom_definitions, [a:1])
+  endif
+endfun
+
+
 if g:switch_mapping != ''
   exe 'nnoremap <silent> '.g:switch_mapping.' :Switch<cr>'
 endif

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -228,18 +228,25 @@ function! s:SwitchReverse()
 endfunction
 
 command! -nargs=* SwitchExtend call s:SwitchExtend(<args>)
-fun! s:SwitchExtend(...) abort
+fun! s:SwitchExtend(...)
   let b:switch_custom_definitions = get(b:, 'switch_custom_definitions',
-      \                                 copy(get(g:, 'switch_custom_definitions', [])))
+        \                               copy(get(g:, 'switch_custom_definitions', [])))
   if a:0 == 0
     echo b:switch_custom_definitions
   else
+    echohl ErrorMsg
     for def in a:000
-      if (type(def) == type({}) || type(def) == type([])) &&
-            \ index(b:switch_custom_definitions, def) < 0
-        call extend(b:switch_custom_definitions, [def])
+      if (type(def) == type({}) || type(def) == type([]))
+        if index(b:switch_custom_definitions, def) < 0
+          call extend(b:switch_custom_definitions, [def])
+        else
+          echomsg 'SwitchExtend: skipping duplicate definition:' string(def)
+        endif
+      else
+        echomsg 'SwitchExtend: args must be lists or dictionaries, skipping:' string(def)
       endif
     endfor
+    echohl None
   endif
 endfun
 

--- a/plugin/switch.vim
+++ b/plugin/switch.vim
@@ -227,16 +227,19 @@ function! s:SwitchReverse()
   silent! call repeat#set(":Switch\<cr>")
 endfunction
 
-command! -nargs=? SwitchExtend call s:SwitchExtend(<args>)
+command! -nargs=* SwitchExtend call s:SwitchExtend(<args>)
 fun! s:SwitchExtend(...) abort
   let b:switch_custom_definitions = get(b:, 'switch_custom_definitions',
       \                                 copy(get(g:, 'switch_custom_definitions', [])))
   if a:0 == 0
     echo b:switch_custom_definitions
-  elseif type(a:1) != type({}) && type(a:1) != type([])
-    echo '[switch.vim] argument must be a list or a dictionary'
-  elseif index(b:switch_custom_definitions, a:1) < 0
-    call extend(b:switch_custom_definitions, [a:1])
+  else
+    for def in a:000
+      if (type(def) == type({}) || type(def) == type([])) &&
+            \ index(b:switch_custom_definitions, def) < 0
+        call extend(b:switch_custom_definitions, [def])
+      endif
+    endfor
   endif
 endfun
 

--- a/spec/plugin/custom_definitions_spec.rb
+++ b/spec/plugin/custom_definitions_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe "Custom definitions" do
+  let(:filename) { 'test.txt' }
+
+  specify 'by setting a buffer-local variable' do
+    set_file_contents 'one'
+    vim.command("let b:switch_custom_definitions = [['one', 'two']]")
+
+    vim.switch
+    assert_file_contents 'two'
+
+    vim.command("let b:switch_custom_definitions = [['two', 'three']]")
+    vim.switch
+    assert_file_contents 'three'
+  end
+
+  specify 'by setting a global variable' do
+    set_file_contents 'one'
+    vim.command("let g:switch_custom_definitions = [['one', 'two']]")
+
+    vim.switch
+    assert_file_contents 'two'
+
+    vim.command("let g:switch_custom_definitions = [['two', 'three']]")
+    vim.switch
+    assert_file_contents 'three'
+  ensure
+    vim.command("unlet g:switch_custom_definitions")
+  end
+
+  describe ":SwitchExtend" do
+    specify "defaults to copying global definitions" do
+      set_file_contents 'one'
+      vim.command("let g:switch_custom_definitions = [['two', 'three']]")
+      vim.command("SwitchExtend {'one': 'two'}")
+
+      vim.switch
+      assert_file_contents 'two'
+
+      vim.switch
+      assert_file_contents 'three'
+    ensure
+      vim.command("unlet g:switch_custom_definitions")
+    end
+
+    specify "allows defining multiple definitions with commas" do
+      set_file_contents 'one'
+      vim.command("SwitchExtend {'one': 'two'}, ['two', 'three']")
+
+      vim.switch
+      assert_file_contents 'two'
+
+      vim.switch
+      assert_file_contents 'three'
+    end
+
+    specify "only applies to buffer" do
+      set_file_contents 'one'
+      vim.command("SwitchExtend ['one', 'two']")
+
+      vim.switch
+      assert_file_contents 'two'
+
+      write_file 'other.txt', 'one'
+      vim.edit 'other.txt'
+
+      vim.switch
+      # no change
+      expect(IO.read('other.txt').strip).to eq 'one'
+    end
+  end
+end


### PR DESCRIPTION
This command provides an easy way to extend the current buffer's custom
definitions (b:switch_custom_definitions). If this variable doesn't
exist yet, it will be created as a copy of the global custom definitions
(g:switch_custom_definitions), and then extended.

Then you can do in the ftplugin:
```vim
silent! SwitchExtend {'\Cif': 'elseif', '\Celseif': 'if'}
```
instead of:
```vim
let b:switch_custom_definitions =
      \ extend(copy(get(g:, 'switch_custom_definitions', [])),
      \        [{'\Cif': 'elseif', '\Celseif': 'if'}])
```

It will also avoid to add duplicate entries.